### PR TITLE
Add endianness check

### DIFF
--- a/GPU/GPUMath.h
+++ b/GPU/GPUMath.h
@@ -23,6 +23,8 @@
 #define NBBLOCK 5
 #define BIFULLSIZE 40
 
+#include "../endian_utils.h"  // why: kernel math assumes little-endian data
+
 // Assembly directives
 #define UADDO(c, a, b) asm volatile ("add.cc.u64 %0, %1, %2;" : "=l"(c) : "l"(a), "l"(b) : "memory" );
 #define UADDC(c, a, b) asm volatile ("addc.cc.u64 %0, %1, %2;" : "=l"(c) : "l"(a), "l"(b) : "memory" );

--- a/SECPK1/Int.h
+++ b/SECPK1/Int.h
@@ -23,6 +23,7 @@
 #include "Random.h"
 #include <string>
 #include <inttypes.h>
+#include "../endian_utils.h"  // why: ensure little-endian compilation
 
 // We need 1 extra block for Knuth div algorithm , Montgomery multiplication and ModInv
 #define BISIZE 256

--- a/endian_utils.h
+++ b/endian_utils.h
@@ -1,0 +1,9 @@
+#ifndef ENDIAN_UTILS_H
+#define ENDIAN_UTILS_H
+
+// compile-time detection of target endianness
+constexpr bool is_little_endian = (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__);
+// why: the algorithm assumes little-endian data layout
+static_assert(is_little_endian, "Kangaroo requires little-endian architecture.");
+
+#endif // ENDIAN_UTILS_H

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -1,0 +1,11 @@
+#include "SECPK1/Int.h"
+#include <iostream>
+
+int main() {
+    if (is_little_endian) {
+        std::cout << "little-endian\n";
+        return 0;
+    }
+    std::cout << "big-endian\n";
+    return 1;
+}


### PR DESCRIPTION
## Summary
- add `endian_utils.h` with compile-time endian detection
- enforce little-endian requirement in Int and GPU math headers
- provide small test to verify

## Testing
- `g++ -std=c++17 -I. tests/test_endian.cpp -o tests/test_endian && ./tests/test_endian`

------
https://chatgpt.com/codex/tasks/task_e_684213033e0883268eff0e7cdac86997